### PR TITLE
don't include tty10.conf file on redhat based distros

### DIFF
--- a/templates/syslog-ng.conf.erb
+++ b/templates/syslog-ng.conf.erb
@@ -1,6 +1,8 @@
 @version: 3.5
 @include "scl.conf"
+<% if @osfamily != 'RedHat'  %>
 @include "`scl-root`/system/tty10.conf"
+<% end %>
 
 options {
     keep_hostname(<%= scope.lookupvar('syslog_ng::keep_hostname') %>);


### PR DESCRIPTION
This file doesn't come installed on the redhat versions of syslog-ng packaged with EPEL.
